### PR TITLE
Feature/avoid athena adapter cache

### DIFF
--- a/app/views/blazer/queries/schema.html.erb
+++ b/app/views/blazer/queries/schema.html.erb
@@ -13,7 +13,7 @@
     <thead>
       <tr>
         <th colspan="2">
-          <% if table[:schema] != "public" %><%= table[:schema] %>.<% end %><%= table[:table] %>
+          <% if !table[:schema].blank? && table[:schema] != "public" %><%= table[:schema] %>.<% end %><%= table[:table] %>
         </th>
       </tr>
     </thead>

--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -12,8 +12,11 @@ module Blazer
           resp =
             client.start_query_execution(
               query_string: statement,
-              # use token so we fetch cached results after query is run
-              client_request_token: Digest::MD5.hexdigest([statement,data_source.id].join("/")),
+              # use token so we fetch cached results after query is
+              # run token valid for a minute, relay the "safe query
+              # requests" to the standard blazer cache
+              timestamp = Time.now.strftime("%d%m%Y%H%M")
+              client_request_token: Digest::MD5.hexdigest([statement, timestamp, data_source.id].join("/")),
               query_execution_context: {
                 database: database,
               },

--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -9,14 +9,16 @@ module Blazer
         error = nil
 
         begin
+          # use token so we fetch cached results after query is
+          # run token valid for a minute, relay the "safe query
+          # requests" to the standard blazer cache
+          timestamp = Time.now.strftime("%d%m%Y%H%M")
+          request_token = Digest::MD5.hexdigest([statement, timestamp, data_source.id].join("/"))
+
           resp =
             client.start_query_execution(
               query_string: statement,
-              # use token so we fetch cached results after query is
-              # run token valid for a minute, relay the "safe query
-              # requests" to the standard blazer cache
-              timestamp = Time.now.strftime("%d%m%Y%H%M")
-              client_request_token: Digest::MD5.hexdigest([statement, timestamp, data_source.id].join("/")),
+              client_request_token: request_token,
               query_execution_context: {
                 database: database,
               },

--- a/lib/blazer/adapters/athena_adapter.rb
+++ b/lib/blazer/adapters/athena_adapter.rb
@@ -12,7 +12,7 @@ module Blazer
           # use token so we fetch cached results after query is
           # run token valid for a minute, relay the "safe query
           # requests" to the standard blazer cache
-          timestamp = Time.now.strftime("%d%m%Y%H%M")
+          timestamp = Time.now.utc.strftime("%d%m%Y%H%M")
           request_token = Digest::MD5.hexdigest([statement, timestamp, data_source.id].join("/"))
 
           resp =


### PR DESCRIPTION
- token base on the current time, minute level: is expected that the caching is managed in general by Blazer and not for Athena. Not using a random value to avoid abuse on resend queries (Athena cost is per data explorer per query)
- table schema prefix not visible is it's empty (avoid to show and empty `.` prefix)